### PR TITLE
netmod/ofi: changes to be able to use cray pmi

### DIFF
--- a/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
+++ b/src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_impl.h
@@ -12,7 +12,13 @@
 
 #include "mpid_nem_impl.h"
 #include "mpihandlemem.h"
+#ifdef USE_PMI2_API
+#include "pmi2.h"
+#define PMIX_SUCCESS PMI2_SUCCESS
+#else
 #include "pmi.h"
+#define PMIX_SUCCESS PMI_SUCCESS
+#endif
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_endpoint.h>
@@ -190,7 +196,7 @@ fn_fail:                      \
   do                                                            \
     {                                                           \
       pmi_errno  = FUNC;                                        \
-      MPIR_ERR_##CHKANDJUMP4(pmi_errno!=PMI_SUCCESS,            \
+      MPIR_ERR_##CHKANDJUMP4(pmi_errno!=PMIX_SUCCESS,            \
                            mpi_errno,                           \
                            MPI_ERR_OTHER,                       \
                            "**ofi_"#STR,                        \


### PR DESCRIPTION
The Cray pmi has some weirdnesses.  It supports
the PMI2 interfaces, but then does things like
doesn't define a PMI2_SUCCESS, nor have a pmi2.h
include file.

Add workarounds to the ofi netmod to allow it
to function when using Cray aprun or native SLURM
srun.

Signed-off-by: Howard Pritchard howardp@lanl.gov

Conflicts:
    src/mpid/ch3/channels/nemesis/netmod/ofi/ofi_init.c
